### PR TITLE
fix import path in demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,9 +57,9 @@ See our [quick start guide](https://github.com/winston0410/camouflage/blob/maste
 
 ```javascript
 import { create } from 'glory'
-import prefixer from 'glory/prefixer'
-import hydration from 'glory/hydration'
-import virtual from 'glory/virtual'
+import prefixer from 'glory/dist/prefixer'
+import hydration from 'glory/dist/hydration'
+import virtual from 'glory/dist/virtual'
 
 const glory = create({
 	//Config renderer here


### PR DESCRIPTION
To allow importing without the dist directory, you may publish the dist directory to npm (instead of the root directory).
If using this approach, you will need to update the "main" and "typings"/"types" field in the package.json (and copy the package.json to the dist folder, and cd to that folder before running "npm publish")